### PR TITLE
Add missing jedis dependency to build.gradle and pom.xml

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
     compile("org.springframework.data:spring-data-redis:1.1.0.RELEASE")
+    compile("redis.clients:jedis:2.1.0")
     compile("cglib:cglib:2.2.2")
     compile("org.slf4j:slf4j-log4j12")
     testCompile("junit:junit")

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -20,6 +20,11 @@
             <version>1.1.0.RELEASE</version>
         </dependency>
         <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
     compile("org.springframework.data:spring-data-redis:1.1.0.RELEASE")
+    compile("redis.clients:jedis:2.1.0")
     compile("cglib:cglib:2.2.2")
     compile("org.slf4j:slf4j-log4j12")
     testCompile("junit:junit")

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -20,6 +20,11 @@
             <version>1.1.0.RELEASE</version>
         </dependency>
         <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>


### PR DESCRIPTION
`Jedis` is an optional dependency in `SD Redis` as one might make use of `Lettuce`, `SRP` or `JRedis`. 

The current `ClassNotFoundException` results in `jedis` depending on `commons-pool` for its configuration which is more or less required by the used  `JedisConnectionFactory`.

---

I also want to point your attention to the fact that with [jedis 2.3](https://github.com/xetorthio/jedis/releases/tag/jedis-2.3.0) the used pool changed to `commons-pool2` which is also used in `SD Redis 1.2.0`.
