### PR TITLE
Make use of Boot's Jedis-based Redis auto-configuration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 tags: [messaging, redis]
 projects: [spring-data-redis]
 ---
-:spring_boot_version: 1.0.2.RELEASE
+:spring_boot_version: 1.1.0.BUILD-SNAPSHOT
 :toc:
 :icons: font
 :source-highlighter: prettify
@@ -112,7 +112,7 @@ Spring Data Redis provides all the components you need to send and receive messa
 
 You'll use the Redis template to send messages and you will register the `Receiver` with the message listener container so that it will receive messages. The connection factory drives both the template and the message listener container, enabling them to connect to the Redis server.
 
-This example sets up a `JedisConnectionFactory`, a Redis connection factory based on the https://github.com/xetorthio/jedis[Jedis] Redis library. That connection factory is injected into both the message listener container and the Redis template.
+This example uses Spring Boot's default `RedisConnectionFactory`, an instance of `JedisConnectionFactory` which is based on the https://github.com/xetorthio/jedis[Jedis] Redis library. The connection factory is injected into both the message listener container and the Redis template.
 
 `src/main/java/hello/Application.java`
 [source,java]

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.0.2.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.1.0.BUILD-SNAPSHOT")
     }
 }
 
@@ -24,9 +24,7 @@ repositories {
 }
 
 dependencies {
-    compile("org.springframework.boot:spring-boot-starter")
-    compile("org.springframework.data:spring-data-redis")
-    compile("redis.clients:jedis:2.1.0")
+    compile("org.springframework.boot:spring-boot-starter-redis")
     testCompile("junit:junit")
 }
 

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -10,22 +10,13 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.0.2.RELEASE</version>
+        <version>1.1.0.BUILD-SNAPSHOT</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-redis</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>redis.clients</groupId>
-            <artifactId>jedis</artifactId>
-            <version>2.1.0</version>
+            <artifactId>spring-boot-starter-redis</artifactId>
         </dependency>
     </dependencies>
 

--- a/complete/src/main/java/hello/Application.java
+++ b/complete/src/main/java/hello/Application.java
@@ -3,11 +3,12 @@ package hello;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
@@ -16,17 +17,13 @@ import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import java.util.concurrent.CountDownLatch;
 
 @Configuration
+@EnableAutoConfiguration
 public class Application {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Application.class);
 
     @Bean
-    JedisConnectionFactory connectionFactory() {
-        return new JedisConnectionFactory();
-    }
-    
-    @Bean
-    RedisMessageListenerContainer container(JedisConnectionFactory connectionFactory,
+    RedisMessageListenerContainer container(RedisConnectionFactory connectionFactory,
                                             MessageListenerAdapter listenerAdapter) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
@@ -50,7 +47,7 @@ public class Application {
     }
     
     @Bean
-    StringRedisTemplate template(JedisConnectionFactory connectionFactory) {
+    StringRedisTemplate template(RedisConnectionFactory connectionFactory) {
         return new StringRedisTemplate(connectionFactory);
     }
     

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.0.2.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.1.0.BUILD-SNAPSHOT")
     }
 }
 
@@ -24,9 +24,7 @@ repositories {
 }
 
 dependencies {
-    compile("org.springframework.boot:spring-boot-starter")
-    compile("org.springframework.data:spring-data-redis")
-    compile("redis.clients:jedis:2.1.0")
+    compile("org.springframework.boot:spring-boot-starter-redis")
     testCompile("junit:junit")
 }
 

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -10,22 +10,13 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.0.2.RELEASE</version>
+        <version>1.1.0.BUILD-SNAPSHOT</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-redis</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>redis.clients</groupId>
-            <artifactId>jedis</artifactId>
-            <version>2.1.0</version>
+            <artifactId>spring-boot-starter-redis</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
I used this guide as part of testing that I'd correctly updated Boot to use Jedis rather than Lettuce. Rather than work being thrown away, I thought it would be worth finishing it off and turning it into a PR to be applied once the Guides are referencing Boot 1.1.0.

Note: the PR is currently using a 1.1.0 snapshot of Boot and should be updated as part of the merge
