### PR TITLE
bump up jedis version

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -28,7 +28,7 @@ repositories {
 dependencies {
     compile("org.springframework.boot:spring-boot-starter")
     compile("org.springframework.data:spring-data-redis")
-    compile("redis.clients:jedis:2.1.0")
+    compile("redis.clients:jedis:2.5.1")
     testCompile("junit:junit")
 }
 

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.1.0</version>
+            <version>2.5.1</version>
         </dependency>
     </dependencies>
 

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -28,7 +28,7 @@ repositories {
 dependencies {
     compile("org.springframework.boot:spring-boot-starter")
     compile("org.springframework.data:spring-data-redis")
-    compile("redis.clients:jedis:2.1.0")
+    compile("redis.clients:jedis:2.5.1")
     testCompile("junit:junit")
 }
 

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.1.0</version>
+            <version>2.5.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Changing jedis version to 2.5.1 resolves the issue here: https://github.com/spring-guides/gs-messaging-redis/issues/3 (java.lang.NoClassDefFoundError: org/apache/commons/pool2/impl/GenericObjectPoolConfig)
