### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -32,7 +32,7 @@ include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/
 
 Before you can build a messaging application, you need to set up the server that will handle receiving and sending messages.
 
-Redis is an open source, BSD-licensed, key-value data store that also comes with a messaging system. The server is freely available at http://redis.io/download. You can download it manually, or if you use a Mac with homebrew:
+Redis is an open source, BSD-licensed, key-value data store that also comes with a messaging system. The server is freely available at https://redis.io/download. You can download it manually, or if you use a Mac with homebrew:
 
 ----
 brew install redis
@@ -58,7 +58,7 @@ You should see a message like this:
   |    `-._   `._    /     _.-'    |     PID: 35142
     `-._    `-._  `-./  _.-'    _.-'
   |`-._`-._    `-.__.-'    _.-'_.-'|
-  |    `-._`-._        _.-'_.-'    |           http://redis.io
+  |    `-._`-._        _.-'_.-'    |           https://redis.io
     `-._    `-._`-.__.-'_.-'    _.-'
   |`-._`-._    `-.__.-'    _.-'_.-'|
   |    `-._`-._        _.-'_.-'    |
@@ -142,7 +142,7 @@ You should see the following output:
 == Summary
 Congratulations! You've just developed a simple publish-and-subscribe application with Spring and Redis.
 
-NOTE: http://gopivotal.com/products/redis[Redis support] is available.
+NOTE: https://pivotal.io/products/redis[Redis support] is available.
 
 == See Also
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://gopivotal.com/products/redis (302) with 1 occurrences migrated to:  
  https://pivotal.io/products/redis ([https](https://gopivotal.com/products/redis) result 200).
* [ ] http://redis.io with 1 occurrences migrated to:  
  https://redis.io ([https](https://redis.io) result 200).
* [ ] http://redis.io/download with 1 occurrences migrated to:  
  https://redis.io/download ([https](https://redis.io/download) result 200).