### PR TITLE
Docker Compose Guide Update

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,6 +2,12 @@
 :icons: font
 :source-highlighter: prettify
 :project_id: gs-messaging-redis
+:java_version: 17
+:build_system: maven
+:build_name: messaging-redis
+:build_version: 0.0.1-SNAPSHOT
+:network_container: guide-redis
+:omit_native_build: y
 
 This guide walks you through the process of using Spring Data Redis to publish and
 subscribe to messages sent with Redis.
@@ -15,89 +21,38 @@ NOTE: It may sound strange to be using Spring Data Redis as the means to publish
 but, as you will discover, Redis provides not only a NoSQL data store but a messaging
 system as well.
 
+include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/guide_introduction.adoc[]
 
-== What You Need
-
-include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/prereq_editor_jdk_buildtools.adoc[]
-+
-- A Redis server (See <<scratch>>)
-
-include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/how_to_complete_this_guide.adoc[]
-
-[[scratch]]
-== Standing up a Redis server
+== Setting up the Redis server
 
 Before you can build a messaging application, you need to set up the server that will
 handle receiving and sending messages.
+include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/docker_compose_support.adoc[]
 
-Redis is an open source, BSD-licensed, key-value data store that also comes with a
-messaging system. The server is freely available at https://redis.io/download. You can
-download it manually, or, if you use a Mac, with Homebrew, by running the following
-command in a terminal window:
+If you choose to run the Redis server yourself instead of using Spring Boot Docker Compose support, you have a few options:
+- https://redis.io/download[Download the server] and manually run it
+- Install with Homebrew, if you use a Mac
+- Manually run the `compose.yaml` file with `docker compose up`
 
-====
-[source,bash]
-----
-brew install redis
-----
-====
-
-Once you unpack Redis, you can launch it with its default settings by running the following command:
-
-====
-[source,bash]
-----
-redis-server
-----
-====
-
-You should see a message similar to the following:
-
-====
-[source,text]
-----
-[35142] 01 May 14:36:28.939 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
-[35142] 01 May 14:36:28.940 * Max number of open files set to 10032
-                _._
-              _.-``__ ''-._
-        _.-``    `.  `_.  ''-._           Redis 2.6.12 (00000000/0) 64 bit
-    .-`` .-```.  ```\/    _.,_ ''-._
-  (    '      ,       .-`  | `,    )     Running in stand alone mode
-  |`-._`-...-` __...-.``-._|'` _.-'|     Port: 6379
-  |    `-._   `._    /     _.-'    |     PID: 35142
-    `-._    `-._  `-./  _.-'    _.-'
-  |`-._`-._    `-.__.-'    _.-'_.-'|
-  |    `-._`-._        _.-'_.-'    |           https://redis.io
-    `-._    `-._`-.__.-'_.-'    _.-'
-  |`-._`-._    `-.__.-'    _.-'_.-'|
-  |    `-._`-._        _.-'_.-'    |
-    `-._    `-._`-.__.-'_.-'    _.-'
-        `-._    `-.__.-'    _.-'
-            `-._        _.-'
-                `-.__.-'
-
-[35142] 01 May 14:36:28.941 # Server started, Redis version 2.6.12
-[35142] 01 May 14:36:28.941 * The server is now ready to accept connections on port 6379
-----
-====
+If you go with any of these alternate approaches, you should remove the `spring-boot-docker-compose` dependency from the Maven or Gradle build file.
+You will also need to add configuration to an `application.properties` file, as described in greater detail in the <<_preparing_to_build_the_application>> section.
+As mentioned earlier, this guide assumes that you use Docker Compose support in Spring Boot, so additional changes to `application.properties` are not required at this point.
 
 [[initial]]
 == Starting with Spring Initializr
 
-You can use this https://start.spring.io/#!type=maven-project&groupId=com.example&artifactId=messaging-redis&name=messaging-redis&description=Demo%20project%20for%20Spring%20Boot&packageName=com.example.messaging-redis&dependencies=data-redis[pre-initialized project] and click Generate to download a ZIP file. This project is configured to fit the examples in this tutorial.
+You can use this https://start.spring.io/#!type=maven-project&groupId=com.example&artifactId=messaging-redis&name=messaging-redis&description=Demo%20project%20for%20Spring%20Boot&packageName=com.example.messaging-redis&dependencies=data-redis,docker-compose[pre-initialized project^] and click Generate to download a ZIP file. This project is configured to fit the examples in this tutorial.
 
 To manually initialize the project:
 
 . Navigate to https://start.spring.io.
 This service pulls in all the dependencies you need for an application and does most of the setup for you.
 . Choose either Gradle or Maven and the language you want to use. This guide assumes that you chose Java.
-. Click *Dependencies* and select *Spring Data Redis*.
+. Click *Dependencies* and select *Spring Data Redis* and *Docker Compose Support*.
 . Click *Generate*.
 . Download the resulting ZIP file, which is an archive of a web application that is configured with your choices.
 
 NOTE: If your IDE has the Spring Initializr integration, you can complete this process from your IDE.
-
-NOTE: You can also fork the project from Github and open it in your IDE or other editor.
 
 == Create a Redis Message Receiver
 
@@ -166,43 +121,52 @@ container bean starts listening for messages. The `main()` method then retrieves
 `Hello from Redis!` message on the `chat` topic. Finally, it closes the Spring application
 context, and the application ends.
 
-include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/build_an_executable_jar_mainhead.adoc[]
+== Run the Application
 
-include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/build_an_executable_jar_with_both.adoc[]
+You can run the main method through your IDE.
+Note that, if you have cloned the project from the solution repository, your IDE may look in the wrong place for the `compose.yaml` file.
+You can configure your IDE to look in the correct place or you could use the command line to run the application.
+The `./gradlew bootRun` and `./mvnw spring-boot:run` commands will launch the application and automatically find the compose.yaml file.
 
-You should see output similar to the following:
+You should see the output:
 
 ====
-[source,text]
+[source,bash]
 ----
-
-  .   ____          _            __ _ _
- /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
-( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
- \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
-  '  |____| .__|_| |_|_| |_\__, | / / / /
- =========|_|==============|___/=/_/_/_/
- :: Spring Boot ::        (v2.1.8.RELEASE)
-
-2019-09-23 12:57:11.578  INFO 35396 --- [           main] c.e.m.MessagingRedisApplication          : Starting MessagingRedisApplication on Jays-MBP with PID 35396 (/Users/j/projects/guides/gs-messaging-redis/complete/target/classes started by j in /Users/j/projects/guides/gs-messaging-redis/complete)
-2019-09-23 12:57:11.581  INFO 35396 --- [           main] c.e.m.MessagingRedisApplication          : No active profile set, falling back to default profiles: default
-2019-09-23 12:57:11.885  INFO 35396 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Multiple Spring Data modules found, entering strict repository configuration mode!
-2019-09-23 12:57:11.887  INFO 35396 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data repositories in DEFAULT mode.
-2019-09-23 12:57:11.914  INFO 35396 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 13ms. Found 0 repository interfaces.
-2019-09-23 12:57:12.685  INFO 35396 --- [    container-1] io.lettuce.core.EpollProvider            : Starting without optional epoll library
-2019-09-23 12:57:12.685  INFO 35396 --- [    container-1] io.lettuce.core.KqueueProvider           : Starting without optional kqueue library
-2019-09-23 12:57:12.848  INFO 35396 --- [           main] c.e.m.MessagingRedisApplication          : Started MessagingRedisApplication in 1.511 seconds (JVM running for 3.685)
-2019-09-23 12:57:12.849  INFO 35396 --- [           main] c.e.m.MessagingRedisApplication          : Sending message...
-2019-09-23 12:57:12.861  INFO 35396 --- [    container-2] com.example.messagingredis.Receiver      : Received <Hello from Redis!>
+yyyy-mm-ddT07:08:48.646-04:00  INFO 18338 --- [main] c.e.m.MessagingRedisApplication: Sending message...
+yyyy-mm-ddT07:08:48.663-04:00  INFO 18338 --- [container-1] com.example.messagingredis.Receiver      : Received <Hello from Redis!>
 ----
 ====
+
+== Preparing to Build the Application
+
+To run the code without Spring Boot Docker Compose support, you need a version of RabbitMQ running locally to connect to.
+To do this, you can use Docker Compose, but you must first make two changes to the `compose.yaml` file.
+First, modify the `ports` entry in `compose.yaml` to be `'6379:6379'`.
+Second, add a `container_name`.
+
+The `compose.yaml` should now be:
+----
+services:
+  redis:
+    container_name: 'guide-redis'
+    image: 'redis:latest'
+    ports:
+      - '6379:6379'
+----
+
+You can now run `docker compose up` to start the Redis server.
+Now you should have an external Redis server that is ready to accept requests.
+You can rerun the application and see the same output using your external Redis server.
+
+NOTE: No configuration is required in the `application.properties` file because the default values match the Redis server configuration in `compose.yaml`. Specifically, the properties `spring.data.redis.host` and `spring.data.redis.port` default to `localhost` and `6379` respectively.
+
+include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/build_and_execute_guide.adoc[]
 
 == Summary
 
 Congratulations! You have just developed a publish-and-subscribe application with Spring
 and Redis.
-
-NOTE: https://pivotal.io/products/redis[Redis support] is available.
 
 == See Also
 

--- a/README.adoc
+++ b/README.adoc
@@ -35,7 +35,7 @@ If you choose to run the Redis server yourself instead of using Spring Boot Dock
 - Manually run the `compose.yaml` file with `docker compose up`
 
 If you go with any of these alternate approaches, you should remove the `spring-boot-docker-compose` dependency from the Maven or Gradle build file.
-You will also need to add configuration to an `application.properties` file, as described in greater detail in the <<_preparing_to_build_the_application>> section.
+You also need to add configuration to an `application.properties` file, as described in greater detail in the <<_preparing_to_build_the_application>> section.
 As mentioned earlier, this guide assumes that you use Docker Compose support in Spring Boot, so additional changes to `application.properties` are not required at this point.
 
 [[initial]]
@@ -126,7 +126,7 @@ context, and the application ends.
 You can run the main method through your IDE.
 Note that, if you have cloned the project from the solution repository, your IDE may look in the wrong place for the `compose.yaml` file.
 You can configure your IDE to look in the correct place or you could use the command line to run the application.
-The `./gradlew bootRun` and `./mvnw spring-boot:run` commands will launch the application and automatically find the compose.yaml file.
+The `./gradlew bootRun` and `./mvnw spring-boot:run` commands launch the application and automatically find the compose.yaml file.
 
 You should see the output:
 
@@ -140,7 +140,7 @@ yyyy-mm-ddT07:08:48.663-04:00  INFO 18338 --- [container-1] com.example.messagin
 
 == Preparing to Build the Application
 
-To run the code without Spring Boot Docker Compose support, you need a version of Redis running locally to connect to.
+To run the code without Spring Boot Docker Compose support, you need a version of Redis running locally.
 To do this, you can use Docker Compose, but you must first make two changes to the `compose.yaml` file.
 First, modify the `ports` entry in `compose.yaml` to be `'6379:6379'`.
 Second, add a `container_name`.

--- a/README.adoc
+++ b/README.adoc
@@ -50,7 +50,7 @@ This service pulls in all the dependencies you need for an application and does 
 . Choose either Gradle or Maven and the language you want to use. This guide assumes that you chose Java.
 . Click *Dependencies* and select *Spring Data Redis* and *Docker Compose Support*.
 . Click *Generate*.
-. Download the resulting ZIP file, which is an archive of a web application that is configured with your choices.
+. Download the resulting ZIP file, which is an archive of an application that is configured with your choices.
 
 NOTE: If your IDE has the Spring Initializr integration, you can complete this process from your IDE.
 

--- a/README.adoc
+++ b/README.adoc
@@ -140,7 +140,7 @@ yyyy-mm-ddT07:08:48.663-04:00  INFO 18338 --- [container-1] com.example.messagin
 
 == Preparing to Build the Application
 
-To run the code without Spring Boot Docker Compose support, you need a version of RabbitMQ running locally to connect to.
+To run the code without Spring Boot Docker Compose support, you need a version of Redis running locally to connect to.
 To do this, you can use Docker Compose, but you must first make two changes to the `compose.yaml` file.
 First, modify the `ports` entry in `compose.yaml` to be `'6379:6379'`.
 Second, add a `container_name`.

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -14,9 +14,12 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }
+

--- a/complete/compose.yaml
+++ b/complete/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  redis:
+    image: 'redis:latest'
+    ports:
+      - '6379'

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -21,7 +21,12 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-redis</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-docker-compose</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -9,7 +9,7 @@
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
-	<artifactId>messaging-redis-complete</artifactId>
+	<artifactId>messaging-redis</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>messaging-redis-complete</name>
 	<description>Demo project for Spring Boot</description>

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -14,9 +14,11 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/initial/compose.yaml
+++ b/initial/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  redis:
+    image: 'redis:latest'
+    ports:
+      - '6379'

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -9,9 +9,9 @@
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
-	<artifactId>messaging-redis-initial</artifactId>
+	<artifactId>messaging-redis</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>messaging-redis</name>
+	<name>messaging-redis-initial</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>17</java.version>
@@ -21,7 +21,12 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-redis</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-docker-compose</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -11,7 +11,7 @@
 	<groupId>com.example</groupId>
 	<artifactId>messaging-redis-initial</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>messaging-redis-initial</name>
+	<name>messaging-redis</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>17</java.version>


### PR DESCRIPTION
This PR rewrites a large portion of the guide to use Spring Boot Docker Compose Support. The pattern is similar to updates previously merged in [MySQL](https://github.com/spring-guides/gs-accessing-data-mysql/pull/61).

Instructions on using Homebrew were removed in favor of a preference to use Spring Boot Docker compose support. This should allow for an easier getting started experience and not be specific to Mac users.

Additionally to adding Docker Compose, a section was added to run the application as a jar file and a Docker container. The Native section of the common file was excluded because this guide will require a custom hint to compile natively.

Also addresses issues #29 and #30.