### PR TITLE
Update CI build and implement dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+
+  - package-ecosystem: "maven"
+    directories:
+      - "/initial"
+      - "/complete"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    schedule:
+      interval: "monthly"
+    target-branch: "main"
+    groups:
+      guide-dependencies-maven:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gradle"
+    directories:
+      - "/initial"
+      - "/complete"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    schedule:
+      interval: "monthly"
+    target-branch: "main"
+    groups:
+      guide-dependencies-gradle:
+        patterns:
+          - "*"

--- a/.github/workflows/continuous-integration-build.yml
+++ b/.github/workflows/continuous-integration-build.yml
@@ -10,32 +10,4 @@ on:
 
 jobs:
   build:
-    name: Build Main Branch
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v3
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: maven
-
-      - name: Build Initial with Maven
-        working-directory: ./initial
-        run: ./mvnw --batch-mode clean package
-
-      - name: Build Initial with Gradle
-        working-directory: ./initial
-        run: ./gradlew build
-
-      - name: Build Complete with Maven
-        working-directory: ./complete
-        run: ./mvnw --batch-mode clean package
-
-      - name: Build Complete with Gradle
-        working-directory: ./complete
-        run: ./gradlew build
+    uses: spring-guides/getting-started-macros/.github/workflows/build_initial_complete_maven_gradle.yml@main

--- a/README.adoc
+++ b/README.adoc
@@ -159,7 +159,7 @@ You can now run `docker compose up` to start the Redis server.
 Now you should have an external Redis server that is ready to accept requests.
 You can rerun the application and see the same output using your external Redis server.
 
-NOTE: No configuration is required in the `application.properties` file because the default values match the Redis server configuration in `compose.yaml`. Specifically, the properties `spring.data.redis.host` and `spring.data.redis.port` default to `localhost` and `6379` respectively.
+NOTE: No configuration is required in the `application.properties` file because the default values match the Redis server configuration in `compose.yaml`. Specifically, the properties `spring.data.redis.host` and `spring.data.redis.port` default to `localhost` and `6379` respectively. More information about connecting to Redis can be found in the https://docs.spring.io/spring-boot/reference/data/nosql.html#data.nosql.redis.connecting[Spring Boot documentation^].
 
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/build_and_execute_guide.adoc[]
 

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -1,8 +1,9 @@
 plugins {
 	id 'org.springframework.boot' version '3.3.0'
-	id 'io.spring.dependency-management' version '1.1.5'
 	id 'java'
 }
+
+apply plugin: 'io.spring.dependency-management'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -1,8 +1,9 @@
 plugins {
 	id 'org.springframework.boot' version '3.3.0'
-	id 'io.spring.dependency-management' version '1.1.5'
 	id 'java'
 }
+
+apply plugin: 'io.spring.dependency-management'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'


### PR DESCRIPTION
This commit adds a new dependabot config file. Additionally, this commit uses a shared CI build that is common across multiple guides. The Gradle build files were modified to adhere to Spring Boot's recommendation and to simplify the Dependabot configuration.